### PR TITLE
Fix android crashes by not setting "name" on a function prototype

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -650,11 +650,12 @@ function buildService(ref, service) {
             "@returns {undefined}",
             "@variation 1"
         ]);
-        push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
+        push(escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
             ++indent;
             push("return this.rpcCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request, callback);");
             --indent;
-        push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
+        push("};");
+        // push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + ", \"name\", { value: " + JSON.stringify(method.name) + " });");
         if (config.comments)
             push("");
         pushComment([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protobufjs",
-  "version": "6.8.7",
+  "version": "6.8.71",
   "versionScheme": "~",
   "description": "Protocol Buffers for JavaScript (& TypeScript).",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",


### PR DESCRIPTION
- fix(android): Don't set 'name' property on rpc prototype function because it crashes android ('attempt to change value of a read-only property set on prototype')